### PR TITLE
Update environment variable name in DomainService

### DIFF
--- a/src/BKA.Tools.CrewFinding.API.Functions/StartupServices/DomainService.cs
+++ b/src/BKA.Tools.CrewFinding.API.Functions/StartupServices/DomainService.cs
@@ -42,7 +42,7 @@ public static class DomainService
 
     private static void AddCrewServices(IServiceCollection service, int maxCrewSize)
     {
-        var expirationThreshold = Convert.ToInt32(Configuration.GetEnvironmentVariable("expirationThreshold"));
+        var expirationThreshold = Convert.ToInt32(Configuration.GetEnvironmentVariable("recentCrewsHoursThreshold"));
 
         service.AddScoped<IRecentCrewsRetrieval>(
             serviceProvider =>


### PR DESCRIPTION
The environment variable name used for setting the crew expiration threshold in the DomainService has been updated. It is now referred to as "recentCrewsHoursThreshold" instead of "expirationThreshold". This change helps clarify its purpose and usage within the application's context.