### PR TITLE
Implement GetCrewsExpiredByDate functionality and improve ExpiredCrew…

### DIFF
--- a/src/BKA.Tools.CrewFinding.DataAccess.CosmosDb.Tests/Repositories/Crews/GetCrewQueryTest.cs
+++ b/src/BKA.Tools.CrewFinding.DataAccess.CosmosDb.Tests/Repositories/Crews/GetCrewQueryTest.cs
@@ -46,7 +46,22 @@ public class GetCrewQueryTest(
         // Assert
         crew.Should().BeNull();
     }
+    
+    [Fact]
+    public async Task Get_Expired_Crews_Successfully()
+    {
+        // Arrange
+        _crewDocument = CrewBuilder.CreateDefaultCrew();
+        await CreateDocument(_crewDocument);
 
+        // Act
+        var crews = await crewQueryRepository.GetCrewsExpiredByDate(_crewDocument.CreatedAt);
+
+        // Assert
+        crews.Should().NotBeEmpty();
+        crews.Should().ContainEquivalentOf(_crewDocument);
+    }
+    
     private async Task CreateDocument(Crew crew)
     {
         var crewDocument = CrewDocument.CreateFromCrew(crew);

--- a/src/BKA.Tools.CrewFinding/Crews/Commands/Expired/ExpiredCrewRemover.cs
+++ b/src/BKA.Tools.CrewFinding/Crews/Commands/Expired/ExpiredCrewRemover.cs
@@ -11,11 +11,8 @@ public class ExpiredCrewRemover(
     public async Task Remove()
     {
         var crews = await crewQueryRepositoryMock.GetCrewsExpiredByDate(DateTime.UtcNow.AddHours(-expirationThreshold));
+        var crewIds = crews.Select(c => c.Id).ToArray();
         
-        if (crews.Length != 0)
-        {
-            var crewIds = crews.Select(c => c.Id).ToArray();
-            await crewCommandRepositoryMock.Disband(crewIds);
-        }
+        await crewCommandRepositoryMock.Disband(crewIds);
     }
 }


### PR DESCRIPTION
…Remover logic

The GetCrewsExpiredByDate method now correctly queries for crews that have expired based on the provided date in the CrewValidationRepository. This implementation replaces the previous placeholder exception. Furthermore, the logic in the ExpiredCrewRemover class was streamlined; it no longer checks whether the length of returned crews is non-zero before disbanding them. Tests were also updated to reflect the new changes and ensure correctness.